### PR TITLE
updated appointments.js

### DIFF
--- a/models/appointments.js
+++ b/models/appointments.js
@@ -12,7 +12,7 @@ Appointments.init(
             autoIncrement: true,
         },
         date: {
-            type: DataTypes.DATE,
+            type: DataTypes.DATEONLY,
             allowNull: false,
         },
         time: {


### PR DESCRIPTION
changed datatype for the appointment date to DATE only from DATE.

This will make it easier for us later when we map the object to be used with nodemailer